### PR TITLE
Remove Failing Default App Test

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -26,10 +26,4 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('general-dashboard');
   });
 
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('general-dashboard app is running!');
-  });
 });


### PR DESCRIPTION
This test was autogenerated with the project,
but has no meaning now. It tests that the content of
the app is equal to a string, but the actual content
has been changed.