### PR TITLE
set usergeneratedreport inactive task

### DIFF
--- a/routes/userGeneratedReports.js
+++ b/routes/userGeneratedReports.js
@@ -45,7 +45,8 @@ module.exports = sequelize => {
       if(obj){
         seqUserGenReports.update({
             input_params_values: req.body.body.input_params_values,
-            chart_type: req.body.body.chart_type
+            chart_type: req.body.body.chart_type,
+            isActive: true
           }, {
             where: {
               user_id_fk: userId,

--- a/src/app/services/users.service.ts
+++ b/src/app/services/users.service.ts
@@ -73,9 +73,9 @@ export class UsersService {
     ).toPromise();
   }
 
-  public updateIsActive(reportID: number, isActive: number): Promise<any>{
+  public updateIsActive(userGeneratedReportID: number, isActive: number): Promise<any>{
     return this.http.put(
-      '/api/userGeneratedReports/' + reportID + '/update',
+      '/api/userGeneratedReports/' + userGeneratedReportID + '/update',
       {
         headers: this.header,
         body: {

--- a/src/app/userhome/userhome.component.html
+++ b/src/app/userhome/userhome.component.html
@@ -23,9 +23,16 @@
       <hr>
     </div>
     <div class="sidebar-heading">Current Widgets</div>
-    <div *ngFor="let report of activeUserGeneratedReports">
+    <div *ngFor="let report of activeUserGeneratedReports" class="dropright list-group-item list-group-item-action bg-light">
       <!-- Add some sort of ngFor loop here to generate current widgets -->
-      <a href="#" class="list-group-item list-group-item-action bg-light">{{report}}</a>
+      <a class="dropright dropdown-toggle" href="#"
+         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{report}}
+      </a>
+      <div class="dropdown-menu">
+        <!-- Dropdown menu links -->
+        <a class="dropdown-item" (click)="setReportInactive(report)">Delete</a>
+      </div>
     </div>
 
   </div>

--- a/src/app/userhome/userhome.component.ts
+++ b/src/app/userhome/userhome.component.ts
@@ -61,6 +61,10 @@ export class UserhomeComponent implements OnInit {
     });
 
   }
+  public setReportInactive(selectedReport: UserGeneratedReport): void{
+    this.userService.updateIsActive(selectedReport.id, 0).then(r => console.log(r));
+    location.reload();
+}
 
 
   isTable(obj: WidgetInfo): boolean{


### PR DESCRIPTION
users can set their current widgets inacitve now by presing delete button. Also added a bit in the create user generated report where it existed to make sure its set active since i ran into a situation where i was recreating a identical report but it was stuck inactive.